### PR TITLE
Enable web-mode on heex templates in Elixir.

### DIFF
--- a/modules/lang/web/+html.el
+++ b/modules/lang/web/+html.el
@@ -4,7 +4,7 @@
   :mode "\\.[px]?html?\\'"
   :mode "\\.\\(?:tpl\\|blade\\)\\(?:\\.php\\)?\\'"
   :mode "\\.erb\\'"
-  :mode "\\.l?eex\\'"
+  :mode "\\.(l|h)?eex\\'"
   :mode "\\.sface\\'"
   :mode "\\.jsp\\'"
   :mode "\\.as[cp]x\\'"


### PR DESCRIPTION
Fixes #5442

Add `heex` to acceptable `web-mode` files.